### PR TITLE
Legger til GET endepunkt for å hente opp vedlegg

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,18 +23,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
-      - name: Cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.3.0
         with:
           java-version: 11
           distribution: 'zulu'
+          cache: 'gradle'
       - name: Test Code
         run: ./gradlew check
 
@@ -46,18 +40,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
-      - name: Cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.3.0
         with:
           java-version: 11
           distribution: 'zulu'
+          cache: 'gradle'
       - name: Build JAR
         run: ./gradlew shadowjar # Creates a combined JAR of project and runTime dependencies.
       - name: Build and publish Docker image

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ val kotlinxCoroutinesVersion = ext.get("kotlinxCoroutinesVersion").toString()
 val fuelVersion = "2.3.1"
 
 plugins {
-    kotlin("jvm") version "1.5.21"
+    kotlin("jvm") version "1.5.30"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
@@ -103,5 +103,5 @@ tasks.withType<ShadowJar> {
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "7.0.1"
+    gradleVersion = "7.2"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/nav/omsorgsdagermeldingapi/felles/Endepunkter.kt
+++ b/src/main/kotlin/no/nav/omsorgsdagermeldingapi/felles/Endepunkter.kt
@@ -4,9 +4,7 @@ const val MELDING_URL_OVERFØRE = "/melding/overforing"
 const val MELDING_URL_FORDELE = "/melding/fordeling"
 const val MELDING_URL_KORONAOVERFØRE = "/melding/koronaoverforing"
 
-
 const val VEDLEGG_URL ="/vedlegg"
-const val SLETTE_VEDLEGG ="/vedlegg/{vedleggId}"
 const val VEDLEGG_MED_ID_URL = "/vedlegg/{vedleggId}"
 
 const val SØKER_URL = "/soker"

--- a/src/main/kotlin/no/nav/omsorgsdagermeldingapi/søknad/melding/MeldingValidator.kt
+++ b/src/main/kotlin/no/nav/omsorgsdagermeldingapi/søknad/melding/MeldingValidator.kt
@@ -215,7 +215,7 @@ internal fun List<Vedlegg>.validerVedlegg(vedleggUrler: List<URL>) {
 }
 
 private fun List<Vedlegg>.validerTotalStorresle() {
-    val totalSize = sumBy { it.content.size }
+    val totalSize = sumOf { it.content.size }
     if (totalSize > MAX_VEDLEGG_SIZE) {
         throw Throwblem(vedleggTooLargeProblemDetails)
     }

--- a/src/main/kotlin/no/nav/omsorgsdagermeldingapi/vedlegg/ProblemDetails.kt
+++ b/src/main/kotlin/no/nav/omsorgsdagermeldingapi/vedlegg/ProblemDetails.kt
@@ -1,0 +1,35 @@
+package no.nav.omsorgsdagermeldingapi.vedlegg
+
+import no.nav.helse.dusseldorf.ktor.core.DefaultProblemDetails
+
+const val MAX_VEDLEGG_SIZE = 8 * 1024 * 1024
+val supportedContentTypes = listOf("application/pdf", "image/jpeg", "image/png")
+val hasToBeMultupartTypeProblemDetails = DefaultProblemDetails(
+    title = "multipart-form-required",
+    status = 400,
+    detail = "Requesten må være en 'multipart/form-data' request hvor en 'part' er en fil, har 'name=vedlegg' og har Content-Type header satt."
+)
+val vedleggNotAttachedProblemDetails = DefaultProblemDetails(
+    title = "attachment-not-attached",
+    status = 400,
+    detail = "Fant ingen 'part' som er en fil, har 'name=vedlegg' og har Content-Type header satt."
+)
+val vedleggTooLargeProblemDetails = DefaultProblemDetails(
+    title = "attachment-too-large",
+    status = 413,
+    detail = "vedlegget var over maks tillatt størrelse på 8MB."
+)
+val fantIkkeSubjectPaaToken =
+    DefaultProblemDetails(title = "fant-ikke-subject", status = 413, detail = "Fant ikke subject på idToken")
+val vedleggContentTypeNotSupportedProblemDetails = DefaultProblemDetails(
+    title = "attachment-content-type-not-supported",
+    status = 400,
+    detail = "Vedleggets type må være en av $supportedContentTypes"
+)
+internal val feilVedSlettingAvVedlegg =
+    DefaultProblemDetails(title = "feil-ved-sletting", status = 500, detail = "Feil ved sletting av vedlegg")
+val vedleggNotFoundProblemDetails = DefaultProblemDetails(
+    title = "attachment-not-found",
+    status = 404,
+    detail = "Inget vedlegg funnet med etterspurt ID."
+)

--- a/src/main/kotlin/no/nav/omsorgsdagermeldingapi/vedlegg/VedleggApis.kt
+++ b/src/main/kotlin/no/nav/omsorgsdagermeldingapi/vedlegg/VedleggApis.kt
@@ -105,7 +105,7 @@ private suspend fun MultiPartData.getVedlegg(eier: DokumentEier) : Vedlegg? {
 }
 
 
-private fun Vedlegg.isSupportedContentType(): Boolean = supportedContentTypes.contains(contentType.toLowerCase())
+private fun Vedlegg.isSupportedContentType(): Boolean = supportedContentTypes.contains(contentType.lowercase())
 
 private fun ApplicationRequest.isFormMultipart(): Boolean {
     return contentType().withoutParameters().match(ContentType.MultiPart.FormData)


### PR DESCRIPTION
Manglet get endepunkt for å hente vedlegg. Første til at frontend bare viste bruker en blank side dersom de ville se vedleggene som var lastet opp.

Oppdaterer også actions, gradle wrapper og kotlin jvm.

* Closes #71 